### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/scripts/render_readme.py
+++ b/scripts/render_readme.py
@@ -2,6 +2,7 @@
 import os
 import re
 import subprocess
+from urllib.parse import urlparse
 
 OUTPUT = 'README.md'
 
@@ -156,7 +157,14 @@ def ensure_badge_links():
         img_url = im.group(1).strip() if im else ''
         img_parsed = extract_owner_repo_from_url(img_url) if img_url else None
         # If it's a GitHub actions badge for this repo, link to the workflow page
-        if img_url and 'github.com' in img_url and '/actions/workflows/' in img_url and img_parsed == (owner.lower(), repo.lower()):
+        if img_url:
+            parsed = urlparse(img_url)
+            host = (parsed.hostname or '').lower()
+            path = parsed.path or ''
+        else:
+            host = ''
+            path = ''
+        if img_url and host == 'github.com' and '/actions/workflows/' in path and img_parsed == (owner.lower(), repo.lower()):
             mb = re.search(r'/actions/workflows/(?P<wf>[^/]+)(?:/badge\.svg(?:\?.*)?)?$', img_url)
             wf_basename = mb.group('wf') if mb else None
             alt_name = os.path.splitext(wf_basename)[0] if wf_basename else None


### PR DESCRIPTION
Potential fix for [https://github.com/zaxlofful/SimpleWish/security/code-scanning/2](https://github.com/zaxlofful/SimpleWish/security/code-scanning/2)

In general, to fix this kind of problem you should parse the URL and inspect its host (and path), instead of checking for substrings like `'github.com' in url`. For GitHub URLs, this means using `urllib.parse.urlparse` (or similar) to get `parsed.hostname` and compare it to `github.com` (or an allowlist), and then examining `parsed.path` for `/actions/workflows/`.

For this specific code in `scripts/render_readme.py`, the best targeted fix is:

- Parse `img_url` using `urllib.parse.urlparse`.
- Require that `parsed.hostname` is exactly `github.com` (case‑insensitive). This avoids accepting URLs like `https://notgithub.com/...` or `https://evil.com/github.com/...`.
- Check that `parsed.path` contains `/actions/workflows/` in the expected position, rather than using a substring on the full URL.
- Replace the condition on line 159 with one that uses these parsed components, while keeping the rest of the behavior (deriving `wf_basename`, `alt_name`, and building `workflow_link`) unchanged.

Concretely:

- Add `from urllib.parse import urlparse` to the imports at the top of `scripts/render_readme.py`.
- In `standalone_repl`, replace the condition

  ```python
  if img_url and 'github.com' in img_url and '/actions/workflows/' in img_url and img_parsed == (owner.lower(), repo.lower()):
  ```

  with logic that:

  - Parses `img_url` into `parsed = urlparse(img_url)`.
  - Computes `host = (parsed.hostname or "").lower()` and `path = parsed.path or ""`.
  - Checks `host == 'github.com'` and `'/actions/workflows/' in path` along with the existing `img_parsed == (owner.lower(), repo.lower())`.

No changes to other files or behavior are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
